### PR TITLE
Added redirect Uri to GenerateAccessTokenAsync

### DIFF
--- a/GoogleCloudPrintApi/Infrastructures/GoogleOAuth2ProviderBase.cs
+++ b/GoogleCloudPrintApi/Infrastructures/GoogleOAuth2ProviderBase.cs
@@ -61,13 +61,14 @@ namespace GoogleCloudPrintApi.Infrastructures
                 .ToString();
         }
 
-        /// <summary>
-        /// Get refresh token from authorization code
-        /// </summary>
-        /// <param name="authorizationCode">Authorization code</param>
-        /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>Refresh token & access token</returns>
-        public async Task<Token> GenerateRefreshTokenAsync(string authorizationCode, CancellationToken cancellationToken = default(CancellationToken))
+		/// <summary>
+		/// Get refresh token from authorization code
+		/// </summary>
+		/// <param name="authorizationCode">Authorization code</param>
+		/// <param name="redirectUrl">Same redirect uri used when building authorization url</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns>Refresh token & access token</returns>
+		public async Task<Token> GenerateRefreshTokenAsync(string authorizationCode, string redirectUrl = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await GoogleAccountOAuth2TokenUri
                 .PostUrlEncodedAsync(new
@@ -75,7 +76,7 @@ namespace GoogleCloudPrintApi.Infrastructures
                     code = authorizationCode,
                     client_id = _clientId,
                     client_secret = _clientSecret,
-                    redirect_uri = OAuth2RedirectUri,
+                    redirect_uri = redirectUrl ?? OAuth2RedirectUri,
                     grant_type = OAuth2GrantTypeAuthCode
                 }, cancellationToken)
                 .ReceiveJson<Token>()

--- a/GoogleCloudPrintApi/Infrastructures/IOAuth2Provider.cs
+++ b/GoogleCloudPrintApi/Infrastructures/IOAuth2Provider.cs
@@ -16,7 +16,7 @@ namespace GoogleCloudPrintApi.Infrastructures
 
         string BuildAuthorizationUrl(string redirectUri = null);
 
-        Task<Token> GenerateRefreshTokenAsync(string authorizationCode, CancellationToken cancellationToken = default(CancellationToken));
+        Task<Token> GenerateRefreshTokenAsync(string authorizationCode, string redirectUrl = null, CancellationToken cancellationToken = default(CancellationToken));
 
         Task<Token> GenerateAccessTokenAsync(string refreshToken, CancellationToken cancellationToken = default(CancellationToken));
     }


### PR DESCRIPTION
Without this change it's impossible to use a redirect uri to authenticate

I'd like to add support for submitting print jobs with this api assuming all goes well with this PR. Let me know if you'd be amenable to that.